### PR TITLE
Implement accurate token counting

### DIFF
--- a/webscout/Provider/OPENAI/BLACKBOXAI.py
+++ b/webscout/Provider/OPENAI/BLACKBOXAI.py
@@ -12,7 +12,7 @@ import time
 from webscout.Provider.OPENAI.base import OpenAICompatibleProvider, BaseChat, BaseCompletions
 from webscout.Provider.OPENAI.utils import (
     ChatCompletion, Choice,
-    ChatCompletionMessage, CompletionUsage
+    ChatCompletionMessage, CompletionUsage, count_tokens
 )
 from webscout.litagent import LitAgent, agent
 agent = LitAgent()
@@ -240,8 +240,8 @@ class Completions(BaseCompletions):
             )
 
             # Estimate token usage
-            prompt_tokens = sum(len(str(msg.get("content", ""))) // 4 for msg in messages)
-            completion_tokens = len(full_content) // 4
+            prompt_tokens = sum(count_tokens(str(msg.get("content", ""))) for msg in messages)
+            completion_tokens = count_tokens(full_content)
 
             # Create the final completion object
             completion = ChatCompletion(

--- a/webscout/Provider/OPENAI/Cloudflare.py
+++ b/webscout/Provider/OPENAI/Cloudflare.py
@@ -12,7 +12,7 @@ from uuid import uuid4
 from .base import OpenAICompatibleProvider, BaseChat, BaseCompletions
 from .utils import (
     ChatCompletionChunk, ChatCompletion, Choice, ChoiceDelta,
-    ChatCompletionMessage, CompletionUsage 
+    ChatCompletionMessage, CompletionUsage, count_tokens
 )
 
 from webscout.AIutel import sanitize_stream
@@ -124,8 +124,8 @@ class Completions(BaseCompletions):
                     choice = Choice(index=0, delta=delta, finish_reason=None)
                     
                     # Estimate token usage (very rough estimate)
-                    prompt_tokens = sum(len(msg.get("content", "")) // 4 for msg in payload["messages"])
-                    completion_tokens = len(accumulated_content) // 4
+                    prompt_tokens = sum(count_tokens(msg.get("content", "")) for msg in payload["messages"])
+                    completion_tokens = count_tokens(accumulated_content)
                     
                     chunk = ChatCompletionChunk(
                         id=request_id,
@@ -203,8 +203,8 @@ class Completions(BaseCompletions):
             )
             
             # Estimate token usage (very rough estimate)
-            prompt_tokens = sum(len(msg.get("content", "")) // 4 for msg in payload["messages"])
-            completion_tokens = len(full_content) // 4
+            prompt_tokens = sum(count_tokens(msg.get("content", "")) for msg in payload["messages"])
+            completion_tokens = count_tokens(full_content)
             usage = CompletionUsage(
                 prompt_tokens=prompt_tokens,
                 completion_tokens=completion_tokens,

--- a/webscout/Provider/OPENAI/FreeGemini.py
+++ b/webscout/Provider/OPENAI/FreeGemini.py
@@ -22,7 +22,8 @@ from webscout.Provider.OPENAI.utils import (
     ChoiceDelta,
     CompletionUsage,
     format_prompt,
-    get_system_prompt
+    get_system_prompt,
+    count_tokens
 )
 
 # ANSI escape codes for formatting
@@ -100,7 +101,7 @@ class Completions(BaseCompletions):
             for text_chunk in processed_stream:
                 if text_chunk and isinstance(text_chunk, str):
                     streaming_text += text_chunk
-                    completion_tokens += len(text_chunk) // 4  # Rough estimate
+                    completion_tokens += count_tokens(text_chunk)
                     
                     delta = ChoiceDelta(content=text_chunk, role="assistant")
                     choice = Choice(index=0, delta=delta, finish_reason=None)
@@ -161,8 +162,8 @@ class Completions(BaseCompletions):
                             pass
             
             # Create usage statistics (rough estimate)
-            prompt_tokens = len(str(payload)) // 4
-            completion_tokens = len(full_text_response) // 4
+            prompt_tokens = count_tokens(str(payload))
+            completion_tokens = count_tokens(full_text_response)
             total_tokens = prompt_tokens + completion_tokens
             
             usage = CompletionUsage(

--- a/webscout/Provider/OPENAI/ai4chat.py
+++ b/webscout/Provider/OPENAI/ai4chat.py
@@ -8,7 +8,7 @@ from typing import List, Dict, Optional, Union, Generator, Any
 from .base import OpenAICompatibleProvider, BaseChat, BaseCompletions
 from .utils import (
     ChatCompletionChunk, ChatCompletion, Choice, ChoiceDelta,
-    ChatCompletionMessage, CompletionUsage
+    ChatCompletionMessage, CompletionUsage, count_tokens
 )
 
 # --- AI4Chat Client ---
@@ -62,7 +62,7 @@ class Completions(BaseCompletions):
             full_response = self._get_ai4chat_response(conversation_prompt, country, user_id)
 
             # Track token usage
-            prompt_tokens = len(conversation_prompt.split())
+            prompt_tokens = count_tokens(conversation_prompt)
             completion_tokens = 0
 
             # Stream fixed-size character chunks (e.g., 48 chars)
@@ -71,7 +71,7 @@ class Completions(BaseCompletions):
             while buffer:
                 chunk_text = buffer[:chunk_size]
                 buffer = buffer[chunk_size:]
-                completion_tokens += len(chunk_text.split())
+                completion_tokens += count_tokens(chunk_text)
 
                 if chunk_text.strip():
                     # Create the delta object
@@ -141,8 +141,8 @@ class Completions(BaseCompletions):
             full_response = self._get_ai4chat_response(conversation_prompt, country, user_id)
 
             # Estimate token counts
-            prompt_tokens = len(conversation_prompt.split())
-            completion_tokens = len(full_response.split())
+            prompt_tokens = count_tokens(conversation_prompt)
+            completion_tokens = count_tokens(full_response)
             total_tokens = prompt_tokens + completion_tokens
 
             # Create the message object

--- a/webscout/Provider/OPENAI/c4ai.py
+++ b/webscout/Provider/OPENAI/c4ai.py
@@ -10,7 +10,7 @@ from .base import OpenAICompatibleProvider, BaseChat, BaseCompletions
 from .utils import (
     ChatCompletionChunk, ChatCompletion, Choice, ChoiceDelta,
     ChatCompletionMessage, CompletionUsage,
-    get_system_prompt, get_last_user_message, format_prompt # Import format_prompt
+    get_system_prompt, get_last_user_message, format_prompt, count_tokens
 )
 
 # Attempt to import LitAgent, fallback if not available
@@ -194,8 +194,8 @@ class Completions(BaseCompletions):
             message = ChatCompletionMessage(role="assistant", content=response_text)
             choice = Choice(index=0, message=message, finish_reason="stop")
             # Estimate tokens based on the formatted prompt
-            prompt_tokens = len(prompt) // 4
-            completion_tokens = len(response_text) // 4
+            prompt_tokens = count_tokens(prompt)
+            completion_tokens = count_tokens(response_text)
             usage = CompletionUsage(
                 prompt_tokens=prompt_tokens,
                 completion_tokens=completion_tokens,

--- a/webscout/Provider/OPENAI/chatgpt.py
+++ b/webscout/Provider/OPENAI/chatgpt.py
@@ -12,7 +12,7 @@ from typing import List, Dict, Optional, Union, Generator, Any
 from .base import OpenAICompatibleProvider, BaseChat, BaseCompletions
 from .utils import (
     ChatCompletionChunk, ChatCompletion, Choice, ChoiceDelta,
-    ChatCompletionMessage, CompletionUsage
+    ChatCompletionMessage, CompletionUsage, count_tokens
 )
 
 # ANSI escape codes for formatting
@@ -483,8 +483,8 @@ class Completions(BaseCompletions):
             )
             
             # Estimate token usage (very rough estimate)
-            prompt_tokens = sum(len(msg.get("content", "")) // 4 for msg in messages)
-            completion_tokens = len(full_content) // 4
+            prompt_tokens = sum(count_tokens(msg.get("content", "")) for msg in messages)
+            completion_tokens = count_tokens(full_content)
             usage = CompletionUsage(
                 prompt_tokens=prompt_tokens,
                 completion_tokens=completion_tokens,

--- a/webscout/Provider/OPENAI/chatgptclone.py
+++ b/webscout/Provider/OPENAI/chatgptclone.py
@@ -10,7 +10,7 @@ from typing import List, Dict, Optional, Union, Generator, Any
 from .base import OpenAICompatibleProvider, BaseChat, BaseCompletions
 from .utils import (
     ChatCompletionChunk, ChatCompletion, Choice, ChoiceDelta,
-    ChatCompletionMessage, CompletionUsage
+    ChatCompletionMessage, CompletionUsage, count_tokens
 )
 
 # Attempt to import LitAgent, fallback if not available
@@ -122,7 +122,7 @@ class Completions(BaseCompletions):
 
             # Estimate prompt tokens based on message length
             for msg in payload.get("messages", []):
-                prompt_tokens += len(msg.get("content", "").split())
+                prompt_tokens += count_tokens(msg.get("content", ""))
 
             buffer = ""
             for line in response.iter_content():
@@ -140,7 +140,7 @@ class Completions(BaseCompletions):
                         content = self._client.format_text(content)
 
                         # Update token counts
-                        completion_tokens += 1
+                        completion_tokens += count_tokens(content)
                         total_tokens = prompt_tokens + completion_tokens
 
                         # Create the delta object
@@ -285,9 +285,9 @@ class Completions(BaseCompletions):
             # Estimate token counts
             prompt_tokens = 0
             for msg in payload.get("messages", []):
-                prompt_tokens += len(msg.get("content", "").split())
+                prompt_tokens += count_tokens(msg.get("content", ""))
 
-            completion_tokens = len(full_text.split())
+            completion_tokens = count_tokens(full_text)
             total_tokens = prompt_tokens + completion_tokens
 
             # Create the message object

--- a/webscout/Provider/OPENAI/exaai.py
+++ b/webscout/Provider/OPENAI/exaai.py
@@ -9,7 +9,7 @@ from typing import List, Dict, Optional, Union, Generator, Any
 from .base import OpenAICompatibleProvider, BaseChat, BaseCompletions
 from .utils import (
     ChatCompletionChunk, ChatCompletion, Choice, ChoiceDelta,
-    ChatCompletionMessage, CompletionUsage
+    ChatCompletionMessage, CompletionUsage, count_tokens
 )
 
 # Attempt to import LitAgent, fallback if not available
@@ -119,7 +119,7 @@ class Completions(BaseCompletions):
 
             # Estimate prompt tokens based on message length
             for msg in payload.get("messages", []):
-                prompt_tokens += len(msg.get("content", "").split())
+                prompt_tokens += count_tokens(msg.get("content", ""))
 
             for line in response.iter_lines(decode_unicode=True):
                 if line:
@@ -131,7 +131,7 @@ class Completions(BaseCompletions):
                         content = self._client.format_text(content)
 
                         # Update token counts
-                        completion_tokens += 1
+                        completion_tokens += count_tokens(content)
                         total_tokens = prompt_tokens + completion_tokens
 
                         # Create the delta object
@@ -244,9 +244,9 @@ class Completions(BaseCompletions):
             # Estimate token counts
             prompt_tokens = 0
             for msg in payload.get("messages", []):
-                prompt_tokens += len(msg.get("content", "").split())
+                prompt_tokens += count_tokens(msg.get("content", ""))
 
-            completion_tokens = len(full_text.split())
+            completion_tokens = count_tokens(full_text)
             total_tokens = prompt_tokens + completion_tokens
 
             # Create the message object

--- a/webscout/Provider/OPENAI/exachat.py
+++ b/webscout/Provider/OPENAI/exachat.py
@@ -13,7 +13,8 @@ from .utils import (
     ChatCompletionMessage,
     ChoiceDelta,
     CompletionUsage,
-    format_prompt
+    format_prompt,
+    count_tokens,
 )
 
 # ANSI escape codes for formatting
@@ -167,7 +168,7 @@ class Completions(BaseCompletions):
                         content = data['choices'][0].get('delta', {}).get('content', '')
                         if content:
                             streaming_text += content
-                            completion_tokens += len(content) // 4  # Rough estimate
+                            completion_tokens += count_tokens(content)
                             
                             # Create a delta object for this chunk
                             delta = ChoiceDelta(content=content)
@@ -227,8 +228,8 @@ class Completions(BaseCompletions):
                         continue
 
             # Create usage statistics (estimated)
-            prompt_tokens = len(payload["query"]) // 4
-            completion_tokens = len(full_response) // 4
+            prompt_tokens = count_tokens(payload["query"])
+            completion_tokens = count_tokens(full_response)
             total_tokens = prompt_tokens + completion_tokens
             
             usage = CompletionUsage(

--- a/webscout/Provider/OPENAI/heckai.py
+++ b/webscout/Provider/OPENAI/heckai.py
@@ -12,7 +12,8 @@ from .utils import (
     ChatCompletionMessage,
     ChoiceDelta,
     CompletionUsage,
-    format_prompt
+    format_prompt,
+    count_tokens,
 )
 
 # ANSI escape codes for formatting
@@ -163,8 +164,8 @@ class Completions(BaseCompletions):
                 full_text = full_text.encode('latin1').decode('utf-8')
             except (UnicodeEncodeError, UnicodeDecodeError):
                 pass
-            prompt_tokens = len(payload["question"]) // 4
-            completion_tokens = len(full_text) // 4
+            prompt_tokens = count_tokens(payload["question"])
+            completion_tokens = count_tokens(full_text)
             total_tokens = prompt_tokens + completion_tokens
             usage = CompletionUsage(
                 prompt_tokens=prompt_tokens,

--- a/webscout/Provider/OPENAI/netwrck.py
+++ b/webscout/Provider/OPENAI/netwrck.py
@@ -15,7 +15,8 @@ from .utils import (
     ChoiceDelta,
     CompletionUsage,
     format_prompt,
-    get_system_prompt
+    get_system_prompt,
+    count_tokens,
 )
 
 # ANSI escape codes for formatting
@@ -91,7 +92,7 @@ class Completions(BaseCompletions):
                         # Format the decoded line using the client's formatter
                         formatted_content = self._client.format_text(decoded_line)
                         streaming_text += formatted_content
-                        completion_tokens += len(formatted_content) // 4  # Rough estimate
+                        completion_tokens += count_tokens(formatted_content)
                         
                         # Create a delta object for this chunk
                         delta = ChoiceDelta(content=formatted_content)
@@ -143,8 +144,8 @@ class Completions(BaseCompletions):
             full_response = self._client.format_text(raw_response)
 
             # Create usage statistics (estimated)
-            prompt_tokens = len(payload["query"]) // 4
-            completion_tokens = len(full_response) // 4
+            prompt_tokens = count_tokens(payload["query"])
+            completion_tokens = count_tokens(full_response)
             total_tokens = prompt_tokens + completion_tokens
             
             usage = CompletionUsage(

--- a/webscout/Provider/OPENAI/scirachat.py
+++ b/webscout/Provider/OPENAI/scirachat.py
@@ -9,7 +9,7 @@ from typing import List, Dict, Optional, Union, Generator, Any
 from .base import OpenAICompatibleProvider, BaseChat, BaseCompletions
 from .utils import (
     ChatCompletionChunk, ChatCompletion, Choice, ChoiceDelta,
-    ChatCompletionMessage, CompletionUsage, get_system_prompt
+    ChatCompletionMessage, CompletionUsage, get_system_prompt, count_tokens
 )
 
 # Attempt to import LitAgent, fallback if not available
@@ -118,7 +118,7 @@ class Completions(BaseCompletions):
             total_tokens = 0
             
             # Estimate prompt tokens based on message length
-            prompt_tokens = len(payload.get("messages", [{}])[0].get("content", "").split())
+            prompt_tokens = count_tokens(payload.get("messages", [{}])[0].get("content", ""))
 
             for line in response.iter_lines():
                 if not line:
@@ -268,8 +268,8 @@ class Completions(BaseCompletions):
             full_response = self._client.format_text(full_response)
             
             # Estimate token counts
-            prompt_tokens = len(payload.get("messages", [{}])[0].get("content", "").split())
-            completion_tokens = len(full_response.split())
+            prompt_tokens = count_tokens(payload.get("messages", [{}])[0].get("content", ""))
+            completion_tokens = count_tokens(full_response)
             total_tokens = prompt_tokens + completion_tokens
             
             # Create the message object

--- a/webscout/Provider/OPENAI/standardinput.py
+++ b/webscout/Provider/OPENAI/standardinput.py
@@ -12,7 +12,7 @@ from .base import OpenAICompatibleProvider, BaseChat, BaseCompletions
 from .utils import (
     ChatCompletionChunk, ChatCompletion, Choice, ChoiceDelta,
     ChatCompletionMessage, CompletionUsage,
-    format_prompt, get_system_prompt, get_last_user_message
+    format_prompt, get_system_prompt, get_last_user_message, count_tokens
 )
 
 # Import LitAgent for browser fingerprinting
@@ -159,8 +159,8 @@ class Completions(BaseCompletions):
             )
 
             # Estimate token usage (very rough estimate)
-            prompt_tokens = len(str(payload).split()) * 2
-            completion_tokens = len(full_response.split()) * 2
+            prompt_tokens = count_tokens(str(payload)) * 2
+            completion_tokens = count_tokens(full_response) * 2
             total_tokens = prompt_tokens + completion_tokens
 
             usage = CompletionUsage(

--- a/webscout/Provider/OPENAI/textpollinations.py
+++ b/webscout/Provider/OPENAI/textpollinations.py
@@ -8,7 +8,8 @@ from typing import List, Dict, Optional, Union, Generator, Any
 from .base import OpenAICompatibleProvider, BaseChat, BaseCompletions
 from .utils import (
     ChatCompletionChunk, ChatCompletion, Choice, ChoiceDelta,
-    ChatCompletionMessage, CompletionUsage, ToolCall, ToolFunction
+    ChatCompletionMessage, CompletionUsage, ToolCall, ToolFunction,
+    count_tokens
 )
 
 # Import LitAgent for browser fingerprinting
@@ -227,8 +228,8 @@ class Completions(BaseCompletions):
             )
 
             # Estimate token usage (very rough estimate)
-            prompt_tokens = sum(len(msg.get("content", "")) // 4 for msg in payload.get("messages", []))
-            completion_tokens = len(full_content) // 4
+            prompt_tokens = sum(count_tokens(msg.get("content", "")) for msg in payload.get("messages", []))
+            completion_tokens = count_tokens(full_content)
             usage = CompletionUsage(
                 prompt_tokens=prompt_tokens,
                 completion_tokens=completion_tokens,

--- a/webscout/Provider/OPENAI/typefully.py
+++ b/webscout/Provider/OPENAI/typefully.py
@@ -9,7 +9,7 @@ from .base import OpenAICompatibleProvider, BaseChat, BaseCompletions
 from .utils import (
     ChatCompletionChunk, ChatCompletion, Choice, ChoiceDelta,
     ChatCompletionMessage, CompletionUsage,
-    format_prompt, get_system_prompt  # Import format_prompt and get_system_prompt
+    format_prompt, get_system_prompt, count_tokens  # Import format_prompt and get_system_prompt
 )
 
 # Import LitAgent for browser fingerprinting
@@ -194,8 +194,8 @@ class Completions(BaseCompletions):
             full_text = full_text.replace('\\n', '\n').replace('\\n\\n', '\n\n')
 
             # Estimate token counts
-            prompt_tokens = len(payload.get("prompt", "").split()) + len(payload.get("systemPrompt", "").split())
-            completion_tokens = len(full_text.split())
+            prompt_tokens = count_tokens(payload.get("prompt", "")) + count_tokens(payload.get("systemPrompt", ""))
+            completion_tokens = count_tokens(full_text)
             total_tokens = prompt_tokens + completion_tokens
 
             # Create the message object

--- a/webscout/Provider/OPENAI/typegpt.py
+++ b/webscout/Provider/OPENAI/typegpt.py
@@ -8,7 +8,7 @@ from typing import List, Dict, Optional, Union, Generator, Any
 from .base import OpenAICompatibleProvider, BaseChat, BaseCompletions
 from .utils import (
     ChatCompletionChunk, ChatCompletion, Choice, ChoiceDelta,
-    ChatCompletionMessage, CompletionUsage
+    ChatCompletionMessage, CompletionUsage, count_tokens
 )
 
 # Attempt to import LitAgent, fallback if not available
@@ -90,7 +90,7 @@ class Completions(BaseCompletions):
 
             # Estimate prompt tokens based on message length
             for msg in payload.get("messages", []):
-                prompt_tokens += len(msg.get("content", "").split())
+                prompt_tokens += count_tokens(msg.get("content", ""))
 
             for line in response.iter_lines():
                 if not line:

--- a/webscout/Provider/OPENAI/venice.py
+++ b/webscout/Provider/OPENAI/venice.py
@@ -8,7 +8,7 @@ from typing import List, Dict, Optional, Union, Generator, Any
 from .base import OpenAICompatibleProvider, BaseChat, BaseCompletions
 from .utils import (
     ChatCompletionChunk, ChatCompletion, Choice, ChoiceDelta,
-    ChatCompletionMessage, CompletionUsage
+    ChatCompletionMessage, CompletionUsage, count_tokens
 )
 
 # Attempt to import LitAgent, fallback if not available
@@ -102,8 +102,8 @@ class Completions(BaseCompletions):
             # Estimate prompt tokens based on message length
             prompt_tokens = 0
             for msg in payload.get("prompt", []):
-                prompt_tokens += len(msg.get("content", "").split())
-            prompt_tokens += len(payload.get("systemPrompt", "").split())
+                prompt_tokens += count_tokens(msg.get("content", ""))
+            prompt_tokens += count_tokens(payload.get("systemPrompt", ""))
 
             for line in response.iter_lines():
                 if not line:
@@ -247,9 +247,9 @@ class Completions(BaseCompletions):
             # Estimate token counts
             prompt_tokens = 0
             for msg in payload.get("prompt", []):
-                prompt_tokens += len(msg.get("content", "").split())
-            prompt_tokens += len(payload.get("systemPrompt", "").split())
-            completion_tokens = len(full_text.split())
+                prompt_tokens += count_tokens(msg.get("content", ""))
+            prompt_tokens += count_tokens(payload.get("systemPrompt", ""))
+            completion_tokens = count_tokens(full_text)
             total_tokens = prompt_tokens + completion_tokens
 
             # Create the message object

--- a/webscout/Provider/OPENAI/wisecat.py
+++ b/webscout/Provider/OPENAI/wisecat.py
@@ -9,7 +9,7 @@ from typing import List, Dict, Optional, Union, Generator, Any
 from .base import OpenAICompatibleProvider, BaseChat, BaseCompletions
 from .utils import (
     ChatCompletionChunk, ChatCompletion, Choice, ChoiceDelta,
-    ChatCompletionMessage, CompletionUsage
+    ChatCompletionMessage, CompletionUsage, count_tokens
 )
 
 # Attempt to import LitAgent, fallback if not available
@@ -104,7 +104,7 @@ class Completions(BaseCompletions):
 
             # Estimate prompt tokens based on message length
             for msg in payload.get("messages", []):
-                prompt_tokens += len(msg.get("content", "").split())
+                prompt_tokens += count_tokens(msg.get("content", ""))
 
             for line in response.iter_lines():
                 if line:
@@ -232,9 +232,9 @@ class Completions(BaseCompletions):
             # Estimate token counts
             prompt_tokens = 0
             for msg in payload.get("messages", []):
-                prompt_tokens += len(msg.get("content", "").split())
+                prompt_tokens += count_tokens(msg.get("content", ""))
 
-            completion_tokens = len(full_text.split())
+            completion_tokens = count_tokens(full_text)
             total_tokens = prompt_tokens + completion_tokens
 
             # Create the message object


### PR DESCRIPTION
## Summary
- import `count_tokens` from utils across providers
- use `count_tokens` to compute prompt and completion tokens for AI providers

## Testing
- `ruff check .`
- `pytest -q` *(fails: command not found)*