### PR TITLE
Add count_tokens usage across providers

### DIFF
--- a/webscout/Provider/OPENAI/ai4chat.py
+++ b/webscout/Provider/OPENAI/ai4chat.py
@@ -8,7 +8,7 @@ from typing import List, Dict, Optional, Union, Generator, Any
 from .base import OpenAICompatibleProvider, BaseChat, BaseCompletions
 from .utils import (
     ChatCompletionChunk, ChatCompletion, Choice, ChoiceDelta,
-    ChatCompletionMessage, CompletionUsage
+    ChatCompletionMessage, CompletionUsage, count_tokens
 )
 
 # --- AI4Chat Client ---
@@ -62,7 +62,7 @@ class Completions(BaseCompletions):
             full_response = self._get_ai4chat_response(conversation_prompt, country, user_id)
 
             # Track token usage
-            prompt_tokens = len(conversation_prompt.split())
+            prompt_tokens = count_tokens(conversation_prompt)
             completion_tokens = 0
 
             # Stream fixed-size character chunks (e.g., 48 chars)
@@ -71,7 +71,7 @@ class Completions(BaseCompletions):
             while buffer:
                 chunk_text = buffer[:chunk_size]
                 buffer = buffer[chunk_size:]
-                completion_tokens += len(chunk_text.split())
+                completion_tokens += count_tokens(chunk_text)
 
                 if chunk_text.strip():
                     # Create the delta object
@@ -141,8 +141,8 @@ class Completions(BaseCompletions):
             full_response = self._get_ai4chat_response(conversation_prompt, country, user_id)
 
             # Estimate token counts
-            prompt_tokens = len(conversation_prompt.split())
-            completion_tokens = len(full_response.split())
+            prompt_tokens = count_tokens(conversation_prompt)
+            completion_tokens = count_tokens(full_response)
             total_tokens = prompt_tokens + completion_tokens
 
             # Create the message object

--- a/webscout/Provider/OPENAI/chatgptclone.py
+++ b/webscout/Provider/OPENAI/chatgptclone.py
@@ -10,7 +10,7 @@ from typing import List, Dict, Optional, Union, Generator, Any
 from .base import OpenAICompatibleProvider, BaseChat, BaseCompletions
 from .utils import (
     ChatCompletionChunk, ChatCompletion, Choice, ChoiceDelta,
-    ChatCompletionMessage, CompletionUsage
+    ChatCompletionMessage, CompletionUsage, count_tokens
 )
 
 # Attempt to import LitAgent, fallback if not available
@@ -122,7 +122,7 @@ class Completions(BaseCompletions):
 
             # Estimate prompt tokens based on message length
             for msg in payload.get("messages", []):
-                prompt_tokens += len(msg.get("content", "").split())
+                prompt_tokens += count_tokens(msg.get("content", ""))
 
             buffer = ""
             for line in response.iter_content():
@@ -139,8 +139,8 @@ class Completions(BaseCompletions):
                         # Format the content (replace escaped newlines)
                         content = self._client.format_text(content)
 
-                        # Update token counts
-                        completion_tokens += 1
+                        # Update token counts using count_tokens
+                        completion_tokens += count_tokens(content)
                         total_tokens = prompt_tokens + completion_tokens
 
                         # Create the delta object
@@ -285,9 +285,9 @@ class Completions(BaseCompletions):
             # Estimate token counts
             prompt_tokens = 0
             for msg in payload.get("messages", []):
-                prompt_tokens += len(msg.get("content", "").split())
+                prompt_tokens += count_tokens(msg.get("content", ""))
 
-            completion_tokens = len(full_text.split())
+            completion_tokens = count_tokens(full_text)
             total_tokens = prompt_tokens + completion_tokens
 
             # Create the message object

--- a/webscout/Provider/OPENAI/exaai.py
+++ b/webscout/Provider/OPENAI/exaai.py
@@ -9,7 +9,7 @@ from typing import List, Dict, Optional, Union, Generator, Any
 from .base import OpenAICompatibleProvider, BaseChat, BaseCompletions
 from .utils import (
     ChatCompletionChunk, ChatCompletion, Choice, ChoiceDelta,
-    ChatCompletionMessage, CompletionUsage
+    ChatCompletionMessage, CompletionUsage, count_tokens
 )
 
 # Attempt to import LitAgent, fallback if not available
@@ -119,7 +119,7 @@ class Completions(BaseCompletions):
 
             # Estimate prompt tokens based on message length
             for msg in payload.get("messages", []):
-                prompt_tokens += len(msg.get("content", "").split())
+                prompt_tokens += count_tokens(msg.get("content", ""))
 
             for line in response.iter_lines(decode_unicode=True):
                 if line:
@@ -131,7 +131,7 @@ class Completions(BaseCompletions):
                         content = self._client.format_text(content)
 
                         # Update token counts
-                        completion_tokens += 1
+                        completion_tokens += count_tokens(content)
                         total_tokens = prompt_tokens + completion_tokens
 
                         # Create the delta object
@@ -244,9 +244,9 @@ class Completions(BaseCompletions):
             # Estimate token counts
             prompt_tokens = 0
             for msg in payload.get("messages", []):
-                prompt_tokens += len(msg.get("content", "").split())
+                prompt_tokens += count_tokens(msg.get("content", ""))
 
-            completion_tokens = len(full_text.split())
+            completion_tokens = count_tokens(full_text)
             total_tokens = prompt_tokens + completion_tokens
 
             # Create the message object

--- a/webscout/Provider/OPENAI/freeaichat.py
+++ b/webscout/Provider/OPENAI/freeaichat.py
@@ -8,7 +8,7 @@ from typing import List, Dict, Optional, Union, Generator, Any
 from .base import OpenAICompatibleProvider, BaseChat, BaseCompletions
 from .utils import (
     ChatCompletionChunk, ChatCompletion, Choice, ChoiceDelta,
-    ChatCompletionMessage, CompletionUsage
+    ChatCompletionMessage, CompletionUsage, count_tokens
 )
 
 # Attempt to import LitAgent, fallback if not available
@@ -84,7 +84,7 @@ class Completions(BaseCompletions):
 
             # Estimate prompt tokens based on message length
             for msg in payload.get("messages", []):
-                prompt_tokens += len(msg.get("content", "").split())
+                prompt_tokens += count_tokens(msg.get("content", ""))
 
             for line in response.iter_lines():
                 if not line:

--- a/webscout/Provider/OPENAI/scirachat.py
+++ b/webscout/Provider/OPENAI/scirachat.py
@@ -9,7 +9,7 @@ from typing import List, Dict, Optional, Union, Generator, Any
 from .base import OpenAICompatibleProvider, BaseChat, BaseCompletions
 from .utils import (
     ChatCompletionChunk, ChatCompletion, Choice, ChoiceDelta,
-    ChatCompletionMessage, CompletionUsage, get_system_prompt
+    ChatCompletionMessage, CompletionUsage, get_system_prompt, count_tokens
 )
 
 # Attempt to import LitAgent, fallback if not available
@@ -118,7 +118,7 @@ class Completions(BaseCompletions):
             total_tokens = 0
             
             # Estimate prompt tokens based on message length
-            prompt_tokens = len(payload.get("messages", [{}])[0].get("content", "").split())
+            prompt_tokens = count_tokens(payload.get("messages", [{}])[0].get("content", ""))
 
             for line in response.iter_lines():
                 if not line:
@@ -135,8 +135,8 @@ class Completions(BaseCompletions):
                         # Format the content (replace escaped newlines)
                         content = self._client.format_text(content)
                         
-                        # Update token counts
-                        completion_tokens += 1
+                        # Update token counts using count_tokens
+                        completion_tokens += count_tokens(content)
                         total_tokens = prompt_tokens + completion_tokens
                         
                         # Create the delta object
@@ -268,8 +268,8 @@ class Completions(BaseCompletions):
             full_response = self._client.format_text(full_response)
             
             # Estimate token counts
-            prompt_tokens = len(payload.get("messages", [{}])[0].get("content", "").split())
-            completion_tokens = len(full_response.split())
+            prompt_tokens = count_tokens(payload.get("messages", [{}])[0].get("content", ""))
+            completion_tokens = count_tokens(full_response)
             total_tokens = prompt_tokens + completion_tokens
             
             # Create the message object

--- a/webscout/Provider/OPENAI/standardinput.py
+++ b/webscout/Provider/OPENAI/standardinput.py
@@ -12,7 +12,7 @@ from .base import OpenAICompatibleProvider, BaseChat, BaseCompletions
 from .utils import (
     ChatCompletionChunk, ChatCompletion, Choice, ChoiceDelta,
     ChatCompletionMessage, CompletionUsage,
-    format_prompt, get_system_prompt, get_last_user_message
+    format_prompt, get_system_prompt, get_last_user_message, count_tokens
 )
 
 # Import LitAgent for browser fingerprinting
@@ -159,8 +159,8 @@ class Completions(BaseCompletions):
             )
 
             # Estimate token usage (very rough estimate)
-            prompt_tokens = len(str(payload).split()) * 2
-            completion_tokens = len(full_response.split()) * 2
+            prompt_tokens = count_tokens(str(payload))
+            completion_tokens = count_tokens(full_response)
             total_tokens = prompt_tokens + completion_tokens
 
             usage = CompletionUsage(

--- a/webscout/Provider/OPENAI/typefully.py
+++ b/webscout/Provider/OPENAI/typefully.py
@@ -9,7 +9,7 @@ from .base import OpenAICompatibleProvider, BaseChat, BaseCompletions
 from .utils import (
     ChatCompletionChunk, ChatCompletion, Choice, ChoiceDelta,
     ChatCompletionMessage, CompletionUsage,
-    format_prompt, get_system_prompt  # Import format_prompt and get_system_prompt
+    format_prompt, get_system_prompt, count_tokens  # Import format_prompt, get_system_prompt and count_tokens
 )
 
 # Import LitAgent for browser fingerprinting
@@ -194,8 +194,8 @@ class Completions(BaseCompletions):
             full_text = full_text.replace('\\n', '\n').replace('\\n\\n', '\n\n')
 
             # Estimate token counts
-            prompt_tokens = len(payload.get("prompt", "").split()) + len(payload.get("systemPrompt", "").split())
-            completion_tokens = len(full_text.split())
+            prompt_tokens = count_tokens(payload.get("prompt", "")) + count_tokens(payload.get("systemPrompt", ""))
+            completion_tokens = count_tokens(full_text)
             total_tokens = prompt_tokens + completion_tokens
 
             # Create the message object

--- a/webscout/Provider/OPENAI/typegpt.py
+++ b/webscout/Provider/OPENAI/typegpt.py
@@ -8,7 +8,7 @@ from typing import List, Dict, Optional, Union, Generator, Any
 from .base import OpenAICompatibleProvider, BaseChat, BaseCompletions
 from .utils import (
     ChatCompletionChunk, ChatCompletion, Choice, ChoiceDelta,
-    ChatCompletionMessage, CompletionUsage
+    ChatCompletionMessage, CompletionUsage, count_tokens
 )
 
 # Attempt to import LitAgent, fallback if not available
@@ -90,7 +90,7 @@ class Completions(BaseCompletions):
 
             # Estimate prompt tokens based on message length
             for msg in payload.get("messages", []):
-                prompt_tokens += len(msg.get("content", "").split())
+                prompt_tokens += count_tokens(msg.get("content", ""))
 
             for line in response.iter_lines():
                 if not line:

--- a/webscout/Provider/OPENAI/venice.py
+++ b/webscout/Provider/OPENAI/venice.py
@@ -8,7 +8,7 @@ from typing import List, Dict, Optional, Union, Generator, Any
 from .base import OpenAICompatibleProvider, BaseChat, BaseCompletions
 from .utils import (
     ChatCompletionChunk, ChatCompletion, Choice, ChoiceDelta,
-    ChatCompletionMessage, CompletionUsage
+    ChatCompletionMessage, CompletionUsage, count_tokens
 )
 
 # Attempt to import LitAgent, fallback if not available
@@ -102,8 +102,8 @@ class Completions(BaseCompletions):
             # Estimate prompt tokens based on message length
             prompt_tokens = 0
             for msg in payload.get("prompt", []):
-                prompt_tokens += len(msg.get("content", "").split())
-            prompt_tokens += len(payload.get("systemPrompt", "").split())
+                prompt_tokens += count_tokens(msg.get("content", ""))
+            prompt_tokens += count_tokens(payload.get("systemPrompt", ""))
 
             for line in response.iter_lines():
                 if not line:
@@ -247,9 +247,9 @@ class Completions(BaseCompletions):
             # Estimate token counts
             prompt_tokens = 0
             for msg in payload.get("prompt", []):
-                prompt_tokens += len(msg.get("content", "").split())
-            prompt_tokens += len(payload.get("systemPrompt", "").split())
-            completion_tokens = len(full_text.split())
+                prompt_tokens += count_tokens(msg.get("content", ""))
+            prompt_tokens += count_tokens(payload.get("systemPrompt", ""))
+            completion_tokens = count_tokens(full_text)
             total_tokens = prompt_tokens + completion_tokens
 
             # Create the message object

--- a/webscout/Provider/OPENAI/wisecat.py
+++ b/webscout/Provider/OPENAI/wisecat.py
@@ -9,7 +9,7 @@ from typing import List, Dict, Optional, Union, Generator, Any
 from .base import OpenAICompatibleProvider, BaseChat, BaseCompletions
 from .utils import (
     ChatCompletionChunk, ChatCompletion, Choice, ChoiceDelta,
-    ChatCompletionMessage, CompletionUsage
+    ChatCompletionMessage, CompletionUsage, count_tokens
 )
 
 # Attempt to import LitAgent, fallback if not available
@@ -104,7 +104,7 @@ class Completions(BaseCompletions):
 
             # Estimate prompt tokens based on message length
             for msg in payload.get("messages", []):
-                prompt_tokens += len(msg.get("content", "").split())
+                prompt_tokens += count_tokens(msg.get("content", ""))
 
             for line in response.iter_lines():
                 if line:
@@ -232,9 +232,9 @@ class Completions(BaseCompletions):
             # Estimate token counts
             prompt_tokens = 0
             for msg in payload.get("messages", []):
-                prompt_tokens += len(msg.get("content", "").split())
+                prompt_tokens += count_tokens(msg.get("content", ""))
 
-            completion_tokens = len(full_text.split())
+            completion_tokens = count_tokens(full_text)
             total_tokens = prompt_tokens + completion_tokens
 
             # Create the message object

--- a/webscout/Provider/OPENAI/writecream.py
+++ b/webscout/Provider/OPENAI/writecream.py
@@ -8,7 +8,7 @@ from typing import List, Dict, Optional, Union, Generator, Any
 from .base import OpenAICompatibleProvider, BaseChat, BaseCompletions
 from .utils import (
     ChatCompletionChunk, ChatCompletion, Choice, ChoiceDelta,
-    ChatCompletionMessage, CompletionUsage
+    ChatCompletionMessage, CompletionUsage, count_tokens
 )
 
 # Attempt to import LitAgent, fallback if not available
@@ -90,8 +90,8 @@ class Completions(BaseCompletions):
             # Extract the response content according to the new API format
             content = data.get("response_content", "")
             # Estimate tokens
-            prompt_tokens = sum(len(m.get("content", "").split()) for m in payload)
-            completion_tokens = len(content.split())
+            prompt_tokens = sum(count_tokens(m.get("content", "")) for m in payload)
+            completion_tokens = count_tokens(content)
             usage = CompletionUsage(
                 prompt_tokens=prompt_tokens,
                 completion_tokens=completion_tokens,


### PR DESCRIPTION
## Summary
- use `count_tokens` in several OpenAI-compatible providers
- improve streaming and non‑streaming token counting

## Testing
- `pytest -q` *(fails: pytest not installed)*