### PR TITLE
Add count_tokens and model_dump usage

### DIFF
--- a/webscout/Provider/OPENAI/BLACKBOXAI.py
+++ b/webscout/Provider/OPENAI/BLACKBOXAI.py
@@ -12,7 +12,7 @@ import time
 from webscout.Provider.OPENAI.base import OpenAICompatibleProvider, BaseChat, BaseCompletions
 from webscout.Provider.OPENAI.utils import (
     ChatCompletion, Choice,
-    ChatCompletionMessage, CompletionUsage
+    ChatCompletionMessage, CompletionUsage, count_tokens
 )
 from webscout.litagent import LitAgent, agent
 agent = LitAgent()
@@ -239,9 +239,9 @@ class Completions(BaseCompletions):
                 finish_reason="stop"
             )
 
-            # Estimate token usage
-            prompt_tokens = sum(len(str(msg.get("content", ""))) // 4 for msg in messages)
-            completion_tokens = len(full_content) // 4
+            # Estimate token usage using count_tokens
+            prompt_tokens = count_tokens([str(msg.get("content", "")) for msg in messages])
+            completion_tokens = count_tokens(full_content)
 
             # Create the final completion object
             completion = ChatCompletion(

--- a/webscout/Provider/OPENAI/Cloudflare.py
+++ b/webscout/Provider/OPENAI/Cloudflare.py
@@ -12,7 +12,7 @@ from uuid import uuid4
 from .base import OpenAICompatibleProvider, BaseChat, BaseCompletions
 from .utils import (
     ChatCompletionChunk, ChatCompletion, Choice, ChoiceDelta,
-    ChatCompletionMessage, CompletionUsage 
+    ChatCompletionMessage, CompletionUsage, count_tokens
 )
 
 from webscout.AIutel import sanitize_stream
@@ -123,9 +123,9 @@ class Completions(BaseCompletions):
                     delta = ChoiceDelta(content=content_chunk)
                     choice = Choice(index=0, delta=delta, finish_reason=None)
                     
-                    # Estimate token usage (very rough estimate)
-                    prompt_tokens = sum(len(msg.get("content", "")) // 4 for msg in payload["messages"])
-                    completion_tokens = len(accumulated_content) // 4
+                    # Estimate token usage using count_tokens
+                    prompt_tokens = count_tokens([msg.get("content", "") for msg in payload["messages"]])
+                    completion_tokens = count_tokens(accumulated_content)
                     
                     chunk = ChatCompletionChunk(
                         id=request_id,
@@ -202,9 +202,9 @@ class Completions(BaseCompletions):
                 finish_reason="stop"
             )
             
-            # Estimate token usage (very rough estimate)
-            prompt_tokens = sum(len(msg.get("content", "")) // 4 for msg in payload["messages"])
-            completion_tokens = len(full_content) // 4
+            # Estimate token usage using count_tokens
+            prompt_tokens = count_tokens([msg.get("content", "") for msg in payload["messages"]])
+            completion_tokens = count_tokens(full_content)
             usage = CompletionUsage(
                 prompt_tokens=prompt_tokens,
                 completion_tokens=completion_tokens,

--- a/webscout/Provider/OPENAI/FreeGemini.py
+++ b/webscout/Provider/OPENAI/FreeGemini.py
@@ -22,7 +22,8 @@ from webscout.Provider.OPENAI.utils import (
     ChoiceDelta,
     CompletionUsage,
     format_prompt,
-    get_system_prompt
+    get_system_prompt,
+    count_tokens
 )
 
 # ANSI escape codes for formatting
@@ -100,7 +101,7 @@ class Completions(BaseCompletions):
             for text_chunk in processed_stream:
                 if text_chunk and isinstance(text_chunk, str):
                     streaming_text += text_chunk
-                    completion_tokens += len(text_chunk) // 4  # Rough estimate
+                    completion_tokens += count_tokens(text_chunk)
                     
                     delta = ChoiceDelta(content=text_chunk, role="assistant")
                     choice = Choice(index=0, delta=delta, finish_reason=None)
@@ -160,9 +161,9 @@ class Completions(BaseCompletions):
                             # Skip invalid JSON
                             pass
             
-            # Create usage statistics (rough estimate)
-            prompt_tokens = len(str(payload)) // 4
-            completion_tokens = len(full_text_response) // 4
+            # Create usage statistics using count_tokens
+            prompt_tokens = count_tokens(str(payload))
+            completion_tokens = count_tokens(full_text_response)
             total_tokens = prompt_tokens + completion_tokens
             
             usage = CompletionUsage(

--- a/webscout/Provider/OPENAI/NEMOTRON.py
+++ b/webscout/Provider/OPENAI/NEMOTRON.py
@@ -9,7 +9,7 @@ from typing import List, Dict, Optional, Union, Generator, Any
 from webscout.Provider.OPENAI.base import OpenAICompatibleProvider, BaseChat, BaseCompletions
 from webscout.Provider.OPENAI.utils import (
     ChatCompletionChunk, ChatCompletion, Choice, ChoiceDelta,
-    ChatCompletionMessage, CompletionUsage, format_prompt
+    ChatCompletionMessage, CompletionUsage, format_prompt, count_tokens
 )
 try:
     from webscout.litagent import LitAgent
@@ -89,8 +89,8 @@ class Completions(BaseCompletions):
             pass
         message = ChatCompletionMessage(role="assistant", content=full_response_content)
         choice = Choice(index=0, message=message, finish_reason="stop")
-        prompt_tokens = len(payload.get("content", "")) // 4 
-        completion_tokens = len(full_response_content) // 4
+        prompt_tokens = count_tokens(payload.get("content", ""))
+        completion_tokens = count_tokens(full_response_content)
         usage = CompletionUsage(
             prompt_tokens=prompt_tokens,
             completion_tokens=completion_tokens,

--- a/webscout/Provider/OPENAI/ai4chat.py
+++ b/webscout/Provider/OPENAI/ai4chat.py
@@ -8,7 +8,7 @@ from typing import List, Dict, Optional, Union, Generator, Any
 from .base import OpenAICompatibleProvider, BaseChat, BaseCompletions
 from .utils import (
     ChatCompletionChunk, ChatCompletion, Choice, ChoiceDelta,
-    ChatCompletionMessage, CompletionUsage
+    ChatCompletionMessage, CompletionUsage, count_tokens
 )
 
 # --- AI4Chat Client ---
@@ -62,7 +62,7 @@ class Completions(BaseCompletions):
             full_response = self._get_ai4chat_response(conversation_prompt, country, user_id)
 
             # Track token usage
-            prompt_tokens = len(conversation_prompt.split())
+            prompt_tokens = count_tokens(conversation_prompt)
             completion_tokens = 0
 
             # Stream fixed-size character chunks (e.g., 48 chars)
@@ -71,7 +71,7 @@ class Completions(BaseCompletions):
             while buffer:
                 chunk_text = buffer[:chunk_size]
                 buffer = buffer[chunk_size:]
-                completion_tokens += len(chunk_text.split())
+                completion_tokens += count_tokens(chunk_text)
 
                 if chunk_text.strip():
                     # Create the delta object
@@ -141,8 +141,8 @@ class Completions(BaseCompletions):
             full_response = self._get_ai4chat_response(conversation_prompt, country, user_id)
 
             # Estimate token counts
-            prompt_tokens = len(conversation_prompt.split())
-            completion_tokens = len(full_response.split())
+            prompt_tokens = count_tokens(conversation_prompt)
+            completion_tokens = count_tokens(full_response)
             total_tokens = prompt_tokens + completion_tokens
 
             # Create the message object

--- a/webscout/Provider/OPENAI/c4ai.py
+++ b/webscout/Provider/OPENAI/c4ai.py
@@ -10,7 +10,7 @@ from .base import OpenAICompatibleProvider, BaseChat, BaseCompletions
 from .utils import (
     ChatCompletionChunk, ChatCompletion, Choice, ChoiceDelta,
     ChatCompletionMessage, CompletionUsage,
-    get_system_prompt, get_last_user_message, format_prompt # Import format_prompt
+    get_system_prompt, get_last_user_message, format_prompt, count_tokens # Import format_prompt
 )
 
 # Attempt to import LitAgent, fallback if not available
@@ -194,8 +194,8 @@ class Completions(BaseCompletions):
             message = ChatCompletionMessage(role="assistant", content=response_text)
             choice = Choice(index=0, message=message, finish_reason="stop")
             # Estimate tokens based on the formatted prompt
-            prompt_tokens = len(prompt) // 4
-            completion_tokens = len(response_text) // 4
+            prompt_tokens = count_tokens(prompt)
+            completion_tokens = count_tokens(response_text)
             usage = CompletionUsage(
                 prompt_tokens=prompt_tokens,
                 completion_tokens=completion_tokens,

--- a/webscout/Provider/OPENAI/chatgpt.py
+++ b/webscout/Provider/OPENAI/chatgpt.py
@@ -12,7 +12,7 @@ from typing import List, Dict, Optional, Union, Generator, Any
 from .base import OpenAICompatibleProvider, BaseChat, BaseCompletions
 from .utils import (
     ChatCompletionChunk, ChatCompletion, Choice, ChoiceDelta,
-    ChatCompletionMessage, CompletionUsage
+    ChatCompletionMessage, CompletionUsage, count_tokens
 )
 
 # ANSI escape codes for formatting
@@ -482,9 +482,9 @@ class Completions(BaseCompletions):
                 finish_reason="stop"
             )
             
-            # Estimate token usage (very rough estimate)
-            prompt_tokens = sum(len(msg.get("content", "")) // 4 for msg in messages)
-            completion_tokens = len(full_content) // 4
+            # Estimate token usage using count_tokens
+            prompt_tokens = count_tokens([msg.get("content", "") for msg in messages])
+            completion_tokens = count_tokens(full_content)
             usage = CompletionUsage(
                 prompt_tokens=prompt_tokens,
                 completion_tokens=completion_tokens,

--- a/webscout/Provider/OPENAI/chatgptclone.py
+++ b/webscout/Provider/OPENAI/chatgptclone.py
@@ -10,7 +10,7 @@ from typing import List, Dict, Optional, Union, Generator, Any
 from .base import OpenAICompatibleProvider, BaseChat, BaseCompletions
 from .utils import (
     ChatCompletionChunk, ChatCompletion, Choice, ChoiceDelta,
-    ChatCompletionMessage, CompletionUsage
+    ChatCompletionMessage, CompletionUsage, count_tokens
 )
 
 # Attempt to import LitAgent, fallback if not available
@@ -122,7 +122,7 @@ class Completions(BaseCompletions):
 
             # Estimate prompt tokens based on message length
             for msg in payload.get("messages", []):
-                prompt_tokens += len(msg.get("content", "").split())
+                prompt_tokens += count_tokens(msg.get("content", ""))
 
             buffer = ""
             for line in response.iter_content():
@@ -139,8 +139,8 @@ class Completions(BaseCompletions):
                         # Format the content (replace escaped newlines)
                         content = self._client.format_text(content)
 
-                        # Update token counts
-                        completion_tokens += 1
+                        # Update token counts using count_tokens
+                        completion_tokens += count_tokens(content)
                         total_tokens = prompt_tokens + completion_tokens
 
                         # Create the delta object
@@ -167,8 +167,11 @@ class Completions(BaseCompletions):
                             system_fingerprint=None
                         )
 
-                        # Convert to dict for proper formatting
-                        chunk_dict = chunk.to_dict()
+                        # Convert chunk to dict using Pydantic's API
+                        if hasattr(chunk, "model_dump"):
+                            chunk_dict = chunk.model_dump(exclude_none=True)
+                        else:
+                            chunk_dict = chunk.dict(exclude_none=True)
 
                         # Add usage information to match OpenAI format
                         usage_dict = {
@@ -211,7 +214,10 @@ class Completions(BaseCompletions):
                 system_fingerprint=None
             )
 
-            chunk_dict = chunk.to_dict()
+            if hasattr(chunk, "model_dump"):
+                chunk_dict = chunk.model_dump(exclude_none=True)
+            else:
+                chunk_dict = chunk.dict(exclude_none=True)
             chunk_dict["usage"] = {
                 "prompt_tokens": prompt_tokens,
                 "completion_tokens": completion_tokens,
@@ -285,9 +291,9 @@ class Completions(BaseCompletions):
             # Estimate token counts
             prompt_tokens = 0
             for msg in payload.get("messages", []):
-                prompt_tokens += len(msg.get("content", "").split())
+                prompt_tokens += count_tokens(msg.get("content", ""))
 
-            completion_tokens = len(full_text.split())
+            completion_tokens = count_tokens(full_text)
             total_tokens = prompt_tokens + completion_tokens
 
             # Create the message object

--- a/webscout/Provider/OPENAI/chatsandbox.py
+++ b/webscout/Provider/OPENAI/chatsandbox.py
@@ -10,7 +10,8 @@ from .utils import (
     ChatCompletionMessage,
     ChoiceDelta,
     CompletionUsage,
-    format_prompt
+    format_prompt,
+    count_tokens
 )
 import requests
 
@@ -124,8 +125,8 @@ class Completions(BaseCompletions):
                     content = data.get("reasoning_content", text)
                 except Exception:
                     content = text
-                prompt_tokens = len(question) // 4
-                completion_tokens = len(content) // 4
+                prompt_tokens = count_tokens(question)
+                completion_tokens = count_tokens(content)
                 total_tokens = prompt_tokens + completion_tokens
                 usage = CompletionUsage(
                     prompt_tokens=prompt_tokens,

--- a/webscout/Provider/OPENAI/copilot.py
+++ b/webscout/Provider/OPENAI/copilot.py
@@ -9,7 +9,7 @@ from curl_cffi.requests import Session, CurlWsFlag
 from .base import OpenAICompatibleProvider, BaseChat, BaseCompletions
 from .utils import (
     ChatCompletionChunk, ChatCompletion, Choice, ChoiceDelta,
-    ChatCompletionMessage, CompletionUsage, format_prompt
+    ChatCompletionMessage, CompletionUsage, format_prompt, count_tokens
 )
 
 # Attempt to import LitAgent, fallback if not available
@@ -90,9 +90,8 @@ class Completions(BaseCompletions):
                 "mode": mode
             }).encode(), CurlWsFlag.TEXT)
 
-            # Track token usage (estimated)
-            # Use a simple approximation: 1 token ≈ 4 characters for English text
-            prompt_tokens = len(prompt_text) // 4
+            # Track token usage using count_tokens
+            prompt_tokens = count_tokens(prompt_text)
             completion_tokens = 0
             total_tokens = prompt_tokens
 
@@ -107,9 +106,8 @@ class Completions(BaseCompletions):
                     started = True
                     content = msg.get("text", "")
                     
-                    # Update token counts (estimated)
-                    # Use a simple approximation: 1 token ≈ 4 characters for English text
-                    content_tokens = len(content) // 4
+                    # Update token counts using count_tokens
+                    content_tokens = count_tokens(content)
                     completion_tokens += content_tokens
                     total_tokens = prompt_tokens + completion_tokens
 
@@ -189,10 +187,9 @@ class Completions(BaseCompletions):
             finish_reason="stop"
         )
 
-        # Estimate token usage
-        # Use a simple approximation: 1 token ≈ 4 characters for English text
-        prompt_tokens = len(prompt_text) // 4
-        completion_tokens = len(result) // 4
+        # Estimate token usage using count_tokens
+        prompt_tokens = count_tokens(prompt_text)
+        completion_tokens = count_tokens(result)
         total_tokens = prompt_tokens + completion_tokens
 
         # Create usage object

--- a/webscout/Provider/OPENAI/deepinfra.py
+++ b/webscout/Provider/OPENAI/deepinfra.py
@@ -125,8 +125,11 @@ class Completions(BaseCompletions):
                                 system_fingerprint=data.get('system_fingerprint')
                             )
 
-                            # Convert to dict for proper formatting
-                            chunk_dict = chunk.to_dict()
+                            # Convert chunk to dict using Pydantic's API
+                            if hasattr(chunk, "model_dump"):
+                                chunk_dict = chunk.model_dump(exclude_none=True)
+                            else:
+                                chunk_dict = chunk.dict(exclude_none=True)
 
                             # Add usage information to match OpenAI format
                             # Even if we don't have real token counts, include estimated usage

--- a/webscout/Provider/OPENAI/e2b.py
+++ b/webscout/Provider/OPENAI/e2b.py
@@ -11,7 +11,7 @@ import requests  # For bypassing Cloudflare protection
 from .base import OpenAICompatibleProvider, BaseChat, BaseCompletions
 from .utils import (
     ChatCompletionChunk, ChatCompletion, Choice, ChoiceDelta,
-    ChatCompletionMessage, CompletionUsage, format_prompt
+    ChatCompletionMessage, CompletionUsage, format_prompt, count_tokens
 )
 
 # Attempt to import LitAgent, fallback if not available
@@ -1039,9 +1039,9 @@ class Completions(BaseCompletions):
             model_config = self._client.MODEL_PROMPT[model_id]
             full_response_text = self._send_request(request_body, model_config)
 
-            # Estimate token counts
-            prompt_tokens = sum(len(msg.get("content", [{"text": ""}])[0].get("text", "")) for msg in request_body.get("messages", [])) // 4
-            completion_tokens = len(full_response_text) // 4
+            # Estimate token counts using count_tokens
+            prompt_tokens = count_tokens([msg.get("content", [{"text": ""}])[0].get("text", "") for msg in request_body.get("messages", [])])
+            completion_tokens = count_tokens(full_response_text)
             total_tokens = prompt_tokens + completion_tokens
 
             message = ChatCompletionMessage(role="assistant", content=full_response_text)

--- a/webscout/Provider/OPENAI/exachat.py
+++ b/webscout/Provider/OPENAI/exachat.py
@@ -13,7 +13,8 @@ from .utils import (
     ChatCompletionMessage,
     ChoiceDelta,
     CompletionUsage,
-    format_prompt
+    format_prompt,
+    count_tokens
 )
 
 # ANSI escape codes for formatting
@@ -165,9 +166,9 @@ class Completions(BaseCompletions):
                     data = json.loads(line.decode('utf-8'))
                     if 'choices' in data and len(data['choices']) > 0:
                         content = data['choices'][0].get('delta', {}).get('content', '')
-                        if content:
-                            streaming_text += content
-                            completion_tokens += len(content) // 4  # Rough estimate
+                            if content:
+                                streaming_text += content
+                                completion_tokens += count_tokens(content)
                             
                             # Create a delta object for this chunk
                             delta = ChoiceDelta(content=content)
@@ -227,8 +228,8 @@ class Completions(BaseCompletions):
                         continue
 
             # Create usage statistics (estimated)
-            prompt_tokens = len(payload["query"]) // 4
-            completion_tokens = len(full_response) // 4
+            prompt_tokens = count_tokens(payload.get("query", ""))
+            completion_tokens = count_tokens(full_response)
             total_tokens = prompt_tokens + completion_tokens
             
             usage = CompletionUsage(

--- a/webscout/Provider/OPENAI/freeaichat.py
+++ b/webscout/Provider/OPENAI/freeaichat.py
@@ -8,7 +8,7 @@ from typing import List, Dict, Optional, Union, Generator, Any
 from .base import OpenAICompatibleProvider, BaseChat, BaseCompletions
 from .utils import (
     ChatCompletionChunk, ChatCompletion, Choice, ChoiceDelta,
-    ChatCompletionMessage, CompletionUsage
+    ChatCompletionMessage, CompletionUsage, count_tokens
 )
 
 # Attempt to import LitAgent, fallback if not available
@@ -84,7 +84,7 @@ class Completions(BaseCompletions):
 
             # Estimate prompt tokens based on message length
             for msg in payload.get("messages", []):
-                prompt_tokens += len(msg.get("content", "").split())
+                prompt_tokens += count_tokens(msg.get("content", ""))
 
             for line in response.iter_lines():
                 if not line:

--- a/webscout/Provider/OPENAI/glider.py
+++ b/webscout/Provider/OPENAI/glider.py
@@ -143,8 +143,11 @@ class Completions(BaseCompletions):
                                 system_fingerprint=data.get('system_fingerprint')
                             )
 
-                            # Convert to dict for proper formatting
-                            chunk_dict = chunk.to_dict()
+                            # Convert chunk to dict using Pydantic's API
+                            if hasattr(chunk, "model_dump"):
+                                chunk_dict = chunk.model_dump(exclude_none=True)
+                            else:
+                                chunk_dict = chunk.dict(exclude_none=True)
 
                             # Add usage information to match OpenAI format
                             # Even if we don't have real token counts, include estimated usage

--- a/webscout/Provider/OPENAI/groq.py
+++ b/webscout/Provider/OPENAI/groq.py
@@ -137,8 +137,11 @@ class Completions(BaseCompletions):
                                 system_fingerprint=data.get('system_fingerprint')
                             )
 
-                            # Convert to dict for proper formatting
-                            chunk_dict = chunk.to_dict()
+                            # Convert chunk to dict using Pydantic's API
+                            if hasattr(chunk, "model_dump"):
+                                chunk_dict = chunk.model_dump(exclude_none=True)
+                            else:
+                                chunk_dict = chunk.dict(exclude_none=True)
 
                             # Add usage information to match OpenAI format
                             usage_dict = {

--- a/webscout/Provider/OPENAI/heckai.py
+++ b/webscout/Provider/OPENAI/heckai.py
@@ -12,7 +12,8 @@ from .utils import (
     ChatCompletionMessage,
     ChoiceDelta,
     CompletionUsage,
-    format_prompt
+    format_prompt,
+    count_tokens
 )
 
 # ANSI escape codes for formatting
@@ -163,8 +164,8 @@ class Completions(BaseCompletions):
                 full_text = full_text.encode('latin1').decode('utf-8')
             except (UnicodeEncodeError, UnicodeDecodeError):
                 pass
-            prompt_tokens = len(payload["question"]) // 4
-            completion_tokens = len(full_text) // 4
+            prompt_tokens = count_tokens(payload.get("question", ""))
+            completion_tokens = count_tokens(full_text)
             total_tokens = prompt_tokens + completion_tokens
             usage = CompletionUsage(
                 prompt_tokens=prompt_tokens,

--- a/webscout/Provider/OPENAI/mcpcore.py
+++ b/webscout/Provider/OPENAI/mcpcore.py
@@ -167,9 +167,15 @@ class Completions(BaseCompletions):
                 # system_fingerprint=..., # Can be added if available in final event
             )
             # Add usage to the final chunk dictionary representation if available
-            final_chunk_dict = final_chunk.to_dict()
+            if hasattr(final_chunk, "model_dump"):
+                final_chunk_dict = final_chunk.model_dump(exclude_none=True)
+            else:
+                final_chunk_dict = final_chunk.dict(exclude_none=True)
             if usage_obj:
-                final_chunk_dict["usage"] = usage_obj.to_dict()
+                if hasattr(usage_obj, "model_dump"):
+                    final_chunk_dict["usage"] = usage_obj.model_dump(exclude_none=True)
+                else:
+                    final_chunk_dict["usage"] = usage_obj.dict(exclude_none=True)
 
             # Yield the final dictionary or object as needed by downstream consumers
             # Yielding the object aligns better with the generator type hint

--- a/webscout/Provider/OPENAI/multichat.py
+++ b/webscout/Provider/OPENAI/multichat.py
@@ -9,7 +9,7 @@ from .base import OpenAICompatibleProvider, BaseChat, BaseCompletions
 from .utils import (
     ChatCompletionChunk, ChatCompletion, Choice, ChoiceDelta,
     ChatCompletionMessage, CompletionUsage,
-    format_prompt
+    format_prompt, count_tokens
 )
 
 # Import curl_cffi for Cloudflare bypass
@@ -154,9 +154,9 @@ class Completions(BaseCompletions):
             message = ChatCompletionMessage(role="assistant", content=response_text)
             choice = Choice(index=0, message=message, finish_reason="stop")
 
-            # Estimate token usage (this is approximate)
-            prompt_tokens = len(user_message) // 4  # Rough estimate
-            completion_tokens = len(response_text) // 4  # Rough estimate
+            # Estimate token usage using count_tokens
+            prompt_tokens = count_tokens(user_message)
+            completion_tokens = count_tokens(response_text)
             total_tokens = prompt_tokens + completion_tokens
 
             usage = CompletionUsage(

--- a/webscout/Provider/OPENAI/netwrck.py
+++ b/webscout/Provider/OPENAI/netwrck.py
@@ -15,7 +15,8 @@ from .utils import (
     ChoiceDelta,
     CompletionUsage,
     format_prompt,
-    get_system_prompt
+    get_system_prompt,
+    count_tokens
 )
 
 # ANSI escape codes for formatting
@@ -91,7 +92,7 @@ class Completions(BaseCompletions):
                         # Format the decoded line using the client's formatter
                         formatted_content = self._client.format_text(decoded_line)
                         streaming_text += formatted_content
-                        completion_tokens += len(formatted_content) // 4  # Rough estimate
+                        completion_tokens += count_tokens(formatted_content)
                         
                         # Create a delta object for this chunk
                         delta = ChoiceDelta(content=formatted_content)
@@ -142,9 +143,9 @@ class Completions(BaseCompletions):
             # Format the full response using the client's formatter
             full_response = self._client.format_text(raw_response)
 
-            # Create usage statistics (estimated)
-            prompt_tokens = len(payload["query"]) // 4
-            completion_tokens = len(full_response) // 4
+            # Create usage statistics using count_tokens
+            prompt_tokens = count_tokens(payload.get("query", ""))
+            completion_tokens = count_tokens(full_response)
             total_tokens = prompt_tokens + completion_tokens
             
             usage = CompletionUsage(

--- a/webscout/Provider/OPENAI/oivscode.py
+++ b/webscout/Provider/OPENAI/oivscode.py
@@ -128,7 +128,10 @@ class Completions(BaseCompletions):
                                 system_fingerprint=data.get('system_fingerprint')
                             )
 
-                            chunk_dict = chunk.to_dict()
+                            if hasattr(chunk, "model_dump"):
+                                chunk_dict = chunk.model_dump(exclude_none=True)
+                            else:
+                                chunk_dict = chunk.dict(exclude_none=True)
 
                             usage_dict = {
                                 "prompt_tokens": prompt_tokens or 10,

--- a/webscout/Provider/OPENAI/opkfc.py
+++ b/webscout/Provider/OPENAI/opkfc.py
@@ -9,7 +9,7 @@ from typing import List, Dict, Optional, Union, Generator, Any
 from .base import OpenAICompatibleProvider, BaseChat, BaseCompletions
 from .utils import (
     ChatCompletionChunk, ChatCompletion, Choice, ChoiceDelta,
-    ChatCompletionMessage, CompletionUsage
+    ChatCompletionMessage, CompletionUsage, count_tokens
 )
 
 # ANSI escape codes for formatting
@@ -409,9 +409,9 @@ class Completions(BaseCompletions):
                 finish_reason="stop"
             )
 
-            # Estimate token usage (very rough estimate)
-            prompt_tokens = sum(len(msg.get("content", "")) // 4 for msg in messages)
-            completion_tokens = len(full_content) // 4
+            # Estimate token usage using count_tokens
+            prompt_tokens = count_tokens([msg.get("content", "") for msg in messages])
+            completion_tokens = count_tokens(full_content)
             usage = CompletionUsage(
                 prompt_tokens=prompt_tokens,
                 completion_tokens=completion_tokens,

--- a/webscout/Provider/OPENAI/scirachat.py
+++ b/webscout/Provider/OPENAI/scirachat.py
@@ -9,7 +9,7 @@ from typing import List, Dict, Optional, Union, Generator, Any
 from .base import OpenAICompatibleProvider, BaseChat, BaseCompletions
 from .utils import (
     ChatCompletionChunk, ChatCompletion, Choice, ChoiceDelta,
-    ChatCompletionMessage, CompletionUsage, get_system_prompt
+    ChatCompletionMessage, CompletionUsage, get_system_prompt, count_tokens
 )
 
 # Attempt to import LitAgent, fallback if not available
@@ -118,7 +118,7 @@ class Completions(BaseCompletions):
             total_tokens = 0
             
             # Estimate prompt tokens based on message length
-            prompt_tokens = len(payload.get("messages", [{}])[0].get("content", "").split())
+            prompt_tokens = count_tokens(payload.get("messages", [{}])[0].get("content", ""))
 
             for line in response.iter_lines():
                 if not line:
@@ -135,8 +135,8 @@ class Completions(BaseCompletions):
                         # Format the content (replace escaped newlines)
                         content = self._client.format_text(content)
                         
-                        # Update token counts
-                        completion_tokens += 1
+                        # Update token counts using count_tokens
+                        completion_tokens += count_tokens(content)
                         total_tokens = prompt_tokens + completion_tokens
                         
                         # Create the delta object
@@ -163,8 +163,11 @@ class Completions(BaseCompletions):
                             system_fingerprint=None
                         )
                         
-                        # Convert to dict for proper formatting
-                        chunk_dict = chunk.to_dict()
+                        # Convert chunk to dict using Pydantic's API
+                        if hasattr(chunk, "model_dump"):
+                            chunk_dict = chunk.model_dump(exclude_none=True)
+                        else:
+                            chunk_dict = chunk.dict(exclude_none=True)
                         
                         # Add usage information to match OpenAI format
                         usage_dict = {
@@ -204,7 +207,10 @@ class Completions(BaseCompletions):
                 system_fingerprint=None
             )
             
-            chunk_dict = chunk.to_dict()
+            if hasattr(chunk, "model_dump"):
+                chunk_dict = chunk.model_dump(exclude_none=True)
+            else:
+                chunk_dict = chunk.dict(exclude_none=True)
             chunk_dict["usage"] = {
                 "prompt_tokens": prompt_tokens,
                 "completion_tokens": completion_tokens,
@@ -268,8 +274,8 @@ class Completions(BaseCompletions):
             full_response = self._client.format_text(full_response)
             
             # Estimate token counts
-            prompt_tokens = len(payload.get("messages", [{}])[0].get("content", "").split())
-            completion_tokens = len(full_response.split())
+            prompt_tokens = count_tokens(payload.get("messages", [{}])[0].get("content", ""))
+            completion_tokens = count_tokens(full_response)
             total_tokens = prompt_tokens + completion_tokens
             
             # Create the message object

--- a/webscout/Provider/OPENAI/sonus.py
+++ b/webscout/Provider/OPENAI/sonus.py
@@ -13,7 +13,8 @@ from .utils import (
     ChatCompletionMessage,
     ChoiceDelta,
     CompletionUsage,
-    format_prompt
+    format_prompt,
+    count_tokens
 )
 
 # ANSI escape codes for formatting
@@ -95,7 +96,7 @@ class Completions(BaseCompletions):
                     if "content" in data:
                         content = data["content"]
                         streaming_text += content
-                        completion_tokens += len(content) // 4  # Rough estimate
+                        completion_tokens += count_tokens(content)
                         
                         # Create a delta object for this chunk
                         delta = ChoiceDelta(content=content)
@@ -154,9 +155,9 @@ class Completions(BaseCompletions):
                     except (json.JSONDecodeError, UnicodeDecodeError):
                         continue
 
-            # Create usage statistics (estimated)
-            prompt_tokens = len(files['message'][1]) // 4
-            completion_tokens = len(full_response) // 4
+            # Create usage statistics using count_tokens
+            prompt_tokens = count_tokens(files.get('message', ['',''])[1])
+            completion_tokens = count_tokens(full_response)
             total_tokens = prompt_tokens + completion_tokens
             
             usage = CompletionUsage(

--- a/webscout/Provider/OPENAI/standardinput.py
+++ b/webscout/Provider/OPENAI/standardinput.py
@@ -12,7 +12,7 @@ from .base import OpenAICompatibleProvider, BaseChat, BaseCompletions
 from .utils import (
     ChatCompletionChunk, ChatCompletion, Choice, ChoiceDelta,
     ChatCompletionMessage, CompletionUsage,
-    format_prompt, get_system_prompt, get_last_user_message
+    format_prompt, get_system_prompt, get_last_user_message, count_tokens
 )
 
 # Import LitAgent for browser fingerprinting
@@ -159,8 +159,8 @@ class Completions(BaseCompletions):
             )
 
             # Estimate token usage (very rough estimate)
-            prompt_tokens = len(str(payload).split()) * 2
-            completion_tokens = len(full_response.split()) * 2
+            prompt_tokens = count_tokens(str(payload))
+            completion_tokens = count_tokens(full_response)
             total_tokens = prompt_tokens + completion_tokens
 
             usage = CompletionUsage(

--- a/webscout/Provider/OPENAI/textpollinations.py
+++ b/webscout/Provider/OPENAI/textpollinations.py
@@ -8,7 +8,7 @@ from typing import List, Dict, Optional, Union, Generator, Any
 from .base import OpenAICompatibleProvider, BaseChat, BaseCompletions
 from .utils import (
     ChatCompletionChunk, ChatCompletion, Choice, ChoiceDelta,
-    ChatCompletionMessage, CompletionUsage, ToolCall, ToolFunction
+    ChatCompletionMessage, CompletionUsage, ToolCall, ToolFunction, count_tokens
 )
 
 # Import LitAgent for browser fingerprinting
@@ -226,9 +226,9 @@ class Completions(BaseCompletions):
                 finish_reason="stop"
             )
 
-            # Estimate token usage (very rough estimate)
-            prompt_tokens = sum(len(msg.get("content", "")) // 4 for msg in payload.get("messages", []))
-            completion_tokens = len(full_content) // 4
+            # Estimate token usage using count_tokens
+            prompt_tokens = count_tokens([msg.get("content", "") for msg in payload.get("messages", [])])
+            completion_tokens = count_tokens(full_content)
             usage = CompletionUsage(
                 prompt_tokens=prompt_tokens,
                 completion_tokens=completion_tokens,

--- a/webscout/Provider/OPENAI/typefully.py
+++ b/webscout/Provider/OPENAI/typefully.py
@@ -9,7 +9,7 @@ from .base import OpenAICompatibleProvider, BaseChat, BaseCompletions
 from .utils import (
     ChatCompletionChunk, ChatCompletion, Choice, ChoiceDelta,
     ChatCompletionMessage, CompletionUsage,
-    format_prompt, get_system_prompt  # Import format_prompt and get_system_prompt
+    format_prompt, get_system_prompt, count_tokens  # Import format_prompt, get_system_prompt and count_tokens
 )
 
 # Import LitAgent for browser fingerprinting
@@ -194,8 +194,8 @@ class Completions(BaseCompletions):
             full_text = full_text.replace('\\n', '\n').replace('\\n\\n', '\n\n')
 
             # Estimate token counts
-            prompt_tokens = len(payload.get("prompt", "").split()) + len(payload.get("systemPrompt", "").split())
-            completion_tokens = len(full_text.split())
+            prompt_tokens = count_tokens(payload.get("prompt", "")) + count_tokens(payload.get("systemPrompt", ""))
+            completion_tokens = count_tokens(full_text)
             total_tokens = prompt_tokens + completion_tokens
 
             # Create the message object

--- a/webscout/Provider/OPENAI/typegpt.py
+++ b/webscout/Provider/OPENAI/typegpt.py
@@ -8,7 +8,7 @@ from typing import List, Dict, Optional, Union, Generator, Any
 from .base import OpenAICompatibleProvider, BaseChat, BaseCompletions
 from .utils import (
     ChatCompletionChunk, ChatCompletion, Choice, ChoiceDelta,
-    ChatCompletionMessage, CompletionUsage
+    ChatCompletionMessage, CompletionUsage, count_tokens
 )
 
 # Attempt to import LitAgent, fallback if not available
@@ -90,7 +90,7 @@ class Completions(BaseCompletions):
 
             # Estimate prompt tokens based on message length
             for msg in payload.get("messages", []):
-                prompt_tokens += len(msg.get("content", "").split())
+                prompt_tokens += count_tokens(msg.get("content", ""))
 
             for line in response.iter_lines():
                 if not line:
@@ -140,8 +140,11 @@ class Completions(BaseCompletions):
                             system_fingerprint=data.get('system_fingerprint')
                         )
 
-                        # Convert to dict for proper formatting
-                        chunk_dict = chunk.to_dict()
+                        # Convert chunk to dict using Pydantic's API
+                        if hasattr(chunk, "model_dump"):
+                            chunk_dict = chunk.model_dump(exclude_none=True)
+                        else:
+                            chunk_dict = chunk.dict(exclude_none=True)
 
                         # Add usage information to match OpenAI format
                         usage_dict = {
@@ -188,7 +191,10 @@ class Completions(BaseCompletions):
                 system_fingerprint=None
             )
 
-            chunk_dict = chunk.to_dict()
+            if hasattr(chunk, "model_dump"):
+                chunk_dict = chunk.model_dump(exclude_none=True)
+            else:
+                chunk_dict = chunk.dict(exclude_none=True)
             chunk_dict["usage"] = {
                 "prompt_tokens": prompt_tokens,
                 "completion_tokens": completion_tokens,

--- a/webscout/Provider/OPENAI/uncovrAI.py
+++ b/webscout/Provider/OPENAI/uncovrAI.py
@@ -16,7 +16,8 @@ from .utils import (
     CompletionUsage,
     format_prompt,
     get_system_prompt,
-    get_last_user_message
+    get_last_user_message,
+    count_tokens
 )
 
 # ANSI escape codes for formatting
@@ -276,9 +277,9 @@ class Completions(BaseCompletions):
                 finish_reason="stop"
             )
 
-            # Estimate token usage (this is approximate)
-            prompt_tokens = len(payload["content"]) // 4
-            completion_tokens = len(full_response) // 4
+            # Estimate token usage using count_tokens
+            prompt_tokens = count_tokens(payload.get("content", ""))
+            completion_tokens = count_tokens(full_response)
             total_tokens = prompt_tokens + completion_tokens
 
             usage = CompletionUsage(

--- a/webscout/Provider/OPENAI/venice.py
+++ b/webscout/Provider/OPENAI/venice.py
@@ -8,7 +8,7 @@ from typing import List, Dict, Optional, Union, Generator, Any
 from .base import OpenAICompatibleProvider, BaseChat, BaseCompletions
 from .utils import (
     ChatCompletionChunk, ChatCompletion, Choice, ChoiceDelta,
-    ChatCompletionMessage, CompletionUsage
+    ChatCompletionMessage, CompletionUsage, count_tokens
 )
 
 # Attempt to import LitAgent, fallback if not available
@@ -102,8 +102,8 @@ class Completions(BaseCompletions):
             # Estimate prompt tokens based on message length
             prompt_tokens = 0
             for msg in payload.get("prompt", []):
-                prompt_tokens += len(msg.get("content", "").split())
-            prompt_tokens += len(payload.get("systemPrompt", "").split())
+                prompt_tokens += count_tokens(msg.get("content", ""))
+            prompt_tokens += count_tokens(payload.get("systemPrompt", ""))
 
             for line in response.iter_lines():
                 if not line:
@@ -148,8 +148,11 @@ class Completions(BaseCompletions):
                                 system_fingerprint=None
                             )
 
-                            # Convert to dict for proper formatting
-                            chunk_dict = chunk.to_dict()
+                            # Convert chunk to dict using Pydantic's API
+                            if hasattr(chunk, "model_dump"):
+                                chunk_dict = chunk.model_dump(exclude_none=True)
+                            else:
+                                chunk_dict = chunk.dict(exclude_none=True)
 
                             # Add usage information to match OpenAI format
                             usage_dict = {
@@ -190,7 +193,10 @@ class Completions(BaseCompletions):
                 system_fingerprint=None
             )
 
-            chunk_dict = chunk.to_dict()
+            if hasattr(chunk, "model_dump"):
+                chunk_dict = chunk.model_dump(exclude_none=True)
+            else:
+                chunk_dict = chunk.dict(exclude_none=True)
             chunk_dict["usage"] = {
                 "prompt_tokens": prompt_tokens,
                 "completion_tokens": completion_tokens,
@@ -247,9 +253,9 @@ class Completions(BaseCompletions):
             # Estimate token counts
             prompt_tokens = 0
             for msg in payload.get("prompt", []):
-                prompt_tokens += len(msg.get("content", "").split())
-            prompt_tokens += len(payload.get("systemPrompt", "").split())
-            completion_tokens = len(full_text.split())
+                prompt_tokens += count_tokens(msg.get("content", ""))
+            prompt_tokens += count_tokens(payload.get("systemPrompt", ""))
+            completion_tokens = count_tokens(full_text)
             total_tokens = prompt_tokens + completion_tokens
 
             # Create the message object

--- a/webscout/Provider/OPENAI/writecream.py
+++ b/webscout/Provider/OPENAI/writecream.py
@@ -8,7 +8,7 @@ from typing import List, Dict, Optional, Union, Generator, Any
 from .base import OpenAICompatibleProvider, BaseChat, BaseCompletions
 from .utils import (
     ChatCompletionChunk, ChatCompletion, Choice, ChoiceDelta,
-    ChatCompletionMessage, CompletionUsage
+    ChatCompletionMessage, CompletionUsage, count_tokens
 )
 
 # Attempt to import LitAgent, fallback if not available
@@ -90,8 +90,8 @@ class Completions(BaseCompletions):
             # Extract the response content according to the new API format
             content = data.get("response_content", "")
             # Estimate tokens
-            prompt_tokens = sum(len(m.get("content", "").split()) for m in payload)
-            completion_tokens = len(content.split())
+            prompt_tokens = sum(count_tokens(m.get("content", "")) for m in payload)
+            completion_tokens = count_tokens(content)
             usage = CompletionUsage(
                 prompt_tokens=prompt_tokens,
                 completion_tokens=completion_tokens,


### PR DESCRIPTION
## Summary
- replace old `to_dict()` calls with `model_dump()` or `dict()`
- track token usage with `count_tokens` across many providers

## Testing
- `pytest -q` *(fails: command not found)*