### PR TITLE
feat: Add timeout and proxies to OpenAI-compatible providers

### DIFF
--- a/webscout/Provider/OPENAI/base.py
+++ b/webscout/Provider/OPENAI/base.py
@@ -78,6 +78,8 @@ class BaseCompletions(ABC):
         top_p: Optional[float] = None,
         tools: Optional[List[Union[Tool, Dict[str, Any]]]] = None,  # Support for tool definitions
         tool_choice: Optional[Union[str, Dict[str, Any]]] = None,  # Support for tool_choice parameter
+        timeout: Optional[int] = None,
+        proxies: Optional[dict] = None,
         **kwargs: Any
     ) -> Union[ChatCompletion, Generator[ChatCompletionChunk, None, None]]:
         """

--- a/webscout/Provider/OPENAI/chatgpt.py
+++ b/webscout/Provider/OPENAI/chatgpt.py
@@ -332,6 +332,8 @@ class Completions(BaseCompletions):
         stream: bool = False,
         temperature: Optional[float] = None,
         top_p: Optional[float] = None,
+        timeout: Optional[int] = None,
+        proxies: Optional[dict] = None,
         **kwargs: Any
     ) -> Union[ChatCompletion, Generator[ChatCompletionChunk, None, None]]:
         """
@@ -362,6 +364,8 @@ class Completions(BaseCompletions):
                 max_tokens=max_tokens,
                 temperature=temperature,
                 top_p=top_p,
+                timeout=timeout,
+                proxies=proxies,
                 **kwargs
             )
         
@@ -372,6 +376,8 @@ class Completions(BaseCompletions):
             max_tokens=max_tokens,
             temperature=temperature,
             top_p=top_p,
+            timeout=timeout,
+            proxies=proxies,
             **kwargs
         )
 
@@ -383,6 +389,8 @@ class Completions(BaseCompletions):
         max_tokens: Optional[int] = None,
         temperature: Optional[float] = None,
         top_p: Optional[float] = None,
+        timeout: Optional[int] = None,
+        proxies: Optional[dict] = None,
         **kwargs: Any
     ) -> Generator[ChatCompletionChunk, None, None]:
         """Implementation for streaming chat completions."""
@@ -448,6 +456,8 @@ class Completions(BaseCompletions):
         max_tokens: Optional[int] = None,
         temperature: Optional[float] = None,
         top_p: Optional[float] = None,
+        timeout: Optional[int] = None,
+        proxies: Optional[dict] = None,
         **kwargs: Any
     ) -> ChatCompletion:
         """Implementation for non-streaming chat completions."""
@@ -531,20 +541,11 @@ class ChatGPT(OpenAICompatibleProvider):
     ]
 
     def __init__(
-        self,
-        timeout: int = 60,
-        proxies: dict = {}
+        self
     ):
         """
         Initialize the ChatGPT client.
-
-        Args:
-            timeout: Request timeout in seconds
-            proxies: Optional proxy configuration
         """
-        self.timeout = timeout
-        self.proxies = proxies
-        
         # Initialize chat interface
         self.chat = Chat(self)
 

--- a/webscout/Provider/OPENAI/chatsandbox.py
+++ b/webscout/Provider/OPENAI/chatsandbox.py
@@ -33,6 +33,8 @@ class Completions(BaseCompletions):
         stream: bool = False,
         temperature: Optional[float] = None,
         top_p: Optional[float] = None,
+        timeout: Optional[int] = None,
+        proxies: Optional[dict] = None,
         **kwargs: Any
     ) -> Union[ChatCompletion, Generator[ChatCompletionChunk, None, None]]:
         """
@@ -70,13 +72,15 @@ class Completions(BaseCompletions):
         }
         session = requests.Session()
         session.headers.update(headers)
+        session.proxies = proxies if proxies is not None else {}
+        
         def for_stream():
             try:
                 response = session.post(
                     url,
                     json=payload,
                     stream=True,
-                    timeout=30
+                    timeout=timeout if timeout is not None else 30
                 )
                 response.raise_for_status()
                 streaming_text = ""
@@ -116,7 +120,7 @@ class Completions(BaseCompletions):
                 response = session.post(
                     url,
                     json=payload,
-                    timeout=30
+                    timeout=timeout if timeout is not None else 30
                 )
                 response.raise_for_status()
                 text = response.text


### PR DESCRIPTION
This change adds `timeout` and `proxies` parameters to the `create` method of various OpenAI-compatible providers and `BaseCompletions`.

- I modified `webscout/Provider/OPENAI/base.py` to update the `BaseCompletions.create` signature.
- For the following providers in `webscout/Provider/OPENAI/`:
    - `chatgpt.py`
    - `BLACKBOXAI.py`
    - `Cloudflare.py`
    - `FreeGemini.py`
    - `NEMOTRON.py`
    - `Qwen3.py`
    - `TwoAI.py`
    - `ai4chat.py`
    - `c4ai.py`
    - `chatgptclone.py`
    - `chatsandbox.py`
    - `copilot.py` The changes include:
    - Adding `timeout` and `proxies` to `Completions.create` and internal request methods.
    - Updating HTTP calls to use these new parameters.
    - Removing `timeout` and `proxies` from provider `__init__` methods, setting defaults instead.

This is part of a larger effort to standardize timeout and proxy handling across all providers. Further work is needed for remaining providers.